### PR TITLE
Enable `fsnotifier`, enable accelerated debugger and upgrade version

### DIFF
--- a/com.jetbrains.PyCharm-Community.appdata.xml
+++ b/com.jetbrains.PyCharm-Community.appdata.xml
@@ -22,7 +22,7 @@
 
     <updatecontact>phracek@redhat.com</updatecontact>
     <releases>
-        <release version="2017.3.4" date="2018-03-06" />
+        <release version="2018.1.3" date="2018-03-28" />
     </releases>
     <content_rating type="oars-1.0">
         <content_attribute id="violence-cartoon">none</content_attribute>

--- a/com.jetbrains.PyCharm-Community.json
+++ b/com.jetbrains.PyCharm-Community.json
@@ -36,6 +36,7 @@
                 "install -dm755 /app/pycharm",
                 "cp -r pycharm-community-2018.1.3/* /app/pycharm",
                 "chmod -R a-s,go+rX,go-w /app/pycharm",
+                "/usr/bin/python3 /app/pycharm/helpers/pydev/setup_cython.py build_ext --inplace",
                 "install pycharm-community-2018.1.3/bin/pycharm.sh /app/bin/pycharm",
                 "install -Dm644 pycharm-community-2018.1.3/bin/pycharm.png /app/share/icons/hicolor/96x96/apps/com.jetbrains.PyCharm-Community.png",
                 "install -Dm644 com.jetbrains.PyCharm-Community.desktop /app/share/applications/com.jetbrains.PyCharm-Community.desktop",

--- a/com.jetbrains.PyCharm-Community.json
+++ b/com.jetbrains.PyCharm-Community.json
@@ -16,8 +16,6 @@
         "--filesystem=host",
         "--socket=session-bus",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.freedesktop.secrets",
-        "--filesystem=xdg-run/keyring",
         "--env=PATH=/usr/bin:/app/bin:/usr/lib/sdk/openjdk9/bin"
     ],
     "modules": [
@@ -32,15 +30,14 @@
             "name": "pycharm",
             "buildsystem": "simple",
             "build-commands": [
-                "tar xzfv pycharm-community-2017.3.4.tar.gz",
-                "rm -f pycharm-community-2017.3.4/bin/fsnotifier*",
-                "rm -f pycharm-community-2017.3.4/help/*",
+                "tar xzfv pycharm-community-2018.1.3.tar.gz",
+                "rm -f pycharm-community-2018.1.3/help/*",
                 "install -dm755 /app/bin",
                 "install -dm755 /app/pycharm",
-                "cp -r pycharm-community-2017.3.4/* /app/pycharm",
+                "cp -r pycharm-community-2018.1.3/* /app/pycharm",
                 "chmod -R a-s,go+rX,go-w /app/pycharm",
-                "install pycharm-community-2017.3.4/bin/pycharm.sh /app/bin/pycharm",
-                "install -Dm644 pycharm-community-2017.3.4/bin/pycharm.png /app/share/icons/hicolor/96x96/apps/com.jetbrains.PyCharm-Community.png",
+                "install pycharm-community-2018.1.3/bin/pycharm.sh /app/bin/pycharm",
+                "install -Dm644 pycharm-community-2018.1.3/bin/pycharm.png /app/share/icons/hicolor/96x96/apps/com.jetbrains.PyCharm-Community.png",
                 "install -Dm644 com.jetbrains.PyCharm-Community.desktop /app/share/applications/com.jetbrains.PyCharm-Community.desktop",
                 "install -Dm644 com.jetbrains.PyCharm-Community.appdata.xml /app/share/appdata/com.jetbrains.PyCharm-Community.appdata.xml",
                 "install -m755 pycharm-desktop /app/bin/pycharm-desktop"
@@ -48,8 +45,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://download.jetbrains.com/python/pycharm-community-2017.3.4.tar.gz",
-                    "sha256": "048810228293c41377bce069eba4905e1e0c12ea7ac83605adeac89cf138fc08"
+                    "url": "https://download.jetbrains.com/python/pycharm-community-2018.1.3.tar.gz",
+                    "sha256": "561976581892ae5e6b924ff3ce61958b30ba1610e191211a4799437359c399b3"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
As per https://github.com/flathub/com.jetbrains.PyCharm-Community/issues/12, https://github.com/flathub/com.jetbrains.PyCharm-Community/issues/19 and https://blog.jetbrains.com/idea/2010/04/native-file-system-watcher-for-linux/, `fsnotifier` is an essential binary. Besides, according to https://github.com/flatpak/flatpak/issues/340#issuecomment-253431307, it will be better for user to override to enable the secret service if needed.