### PR TITLE
Enabling builtin filesystem watcher and accelerated debugger

### DIFF
--- a/com.jetbrains.PyCharm-Community.json
+++ b/com.jetbrains.PyCharm-Community.json
@@ -33,12 +33,12 @@
             "buildsystem": "simple",
             "build-commands": [
                 "tar xzfv pycharm-community-2018.1.4.tar.gz",
-                "rm -f pycharm-community-2018.1.4/bin/fsnotifier*",
                 "rm -f pycharm-community-2018.1.4/help/*",
                 "install -dm755 /app/bin",
                 "install -dm755 /app/pycharm",
                 "cp -r pycharm-community-2018.1.4/* /app/pycharm",
                 "chmod -R a-s,go+rX,go-w /app/pycharm",
+                "/usr/bin/python3 /app/pycharm/helpers/pydev/setup_cython.py build_ext --inplace",
                 "install pycharm-community-2018.1.4/bin/pycharm.sh /app/bin/pycharm",
                 "install -Dm644 pycharm-community-2018.1.4/bin/pycharm.png /app/share/icons/hicolor/96x96/apps/com.jetbrains.PyCharm-Community.png",
                 "install -Dm644 com.jetbrains.PyCharm-Community.desktop /app/share/applications/com.jetbrains.PyCharm-Community.desktop",


### PR DESCRIPTION
Enabling builtin filesystem watcher and accelerated debugger to avoid complaints when PyCharm starts

As per #24  @phracek @nedrichards Thanks