### PR TITLE
Workaround for native file watcher

### DIFF
--- a/com.jetbrains.PyCharm-Community.json
+++ b/com.jetbrains.PyCharm-Community.json
@@ -84,6 +84,7 @@
                     "type": "script",
                     "dest-filename": "pycharm-desktop",
                     "commands": [
+                        "ln -s /proc/mounts /etc/mtab",
                         "exec env PYCHARM_JDK=/app/pycharm/jre64/ PYCHARM_VM_OPTIONS=/app/pycharm/bin/pycharm64.vmoptions /app/pycharm/bin/pycharm.sh \"$@\""
                     ]
                 }


### PR DESCRIPTION
This is a very simple workaround to make the native file watcher
work again.
Before this, users would get the warning:
> External file changes sync may be slow: Native
> file watcher executable not found

Fixes: #19


I don't now flatpak very well, yet, so I don't know why I couldn't use the `build-commands` part instead of `commands`. But it seems to work well for the moment, until this is fixes upstream.