### PR TITLE
Revert "Workaround for native file watcher"

### DIFF
--- a/com.jetbrains.PyCharm-Community.json
+++ b/com.jetbrains.PyCharm-Community.json
@@ -90,7 +90,6 @@
                     "type": "script",
                     "dest-filename": "pycharm-desktop",
                     "commands": [
-                        "ln -s /proc/mounts /etc/mtab",
                         "exec env PYCHARM_JDK=/app/pycharm/jre64/ PYCHARM_VM_OPTIONS=/app/pycharm/bin/pycharm64.vmoptions /app/pycharm/bin/pycharm.sh \"$@\""
                     ]
                 }


### PR DESCRIPTION
The proper fix has landed upstream: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/merge_requests/783
Not sure when this will get distributed to users, but as soon as it does this PR can get merged