### PR TITLE
Fix build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You only need to download sources from www.jetbrains.com/pycharm
 ## How to build PyCharm-Community
 
 ```
-flatpak-builder --repo=repo flatpakbuildir com.jetbrains.PyCharm-Community.json --force-clean
+flatpak-builder --repo=repo flatpakbuildir com.jetbrains.PyCharm-Community.yaml --force-clean
 ```
 
 ## Add PyCharm-Community repo to remote


### PR DESCRIPTION
The build manifest is called `com.jetbrains.PyCharm-Community.yaml`, not `com.jetbrains.PyCharm-Community.json`