### PR TITLE
Update PyCharm to latest version, fix Appstream linter error, update Runtime to 23.08

### DIFF
--- a/com.jetbrains.PyCharm-Community.appdata.xml
+++ b/com.jetbrains.PyCharm-Community.appdata.xml
@@ -17,6 +17,7 @@
 	<url type="help">https://www.jetbrains.com/help/pycharm/</url>
 	<launchable type="desktop-id">com.jetbrains.PyCharm-Community.desktop</launchable>
 	<releases>
+		<release version="2024.1.1" date="2024-04-30"/>
 		<release version="2023.3.3" date="2024-01-26"/>
 		<release version="2023.3.2" date="2023-12-20"/>
 		<release version="2023.3.1" date="2023-12-12"/>

--- a/com.jetbrains.PyCharm-Community.appdata.xml
+++ b/com.jetbrains.PyCharm-Community.appdata.xml
@@ -146,21 +146,20 @@
 				<ul>
 					<li>PyCharm now recognizes ctypes Arrays so now you won’t get wrong inspection messages when defining or using such arrays</li>
 					<li>We had a bug that made Tensorflow’s references to be unresolved and that was also fixed</li>
-					<li>The PyCharm debugger got some fixes:
-						<ul>
-							<li>The issue causing the debugger to hang when a syntax error was encountered was resolved</li>
-							<li>When classes were given certain names, the debugger would be unable to inspect their variables, this is no longer a problem</li>
-							<li>Exceptions thrown when debugging a project with multiprocessing modules will not stop the debugger anymore</li>
-							<li>An issue that caused debugger functions like “Step into” to not work properly in our latest release was solved</li>
-							<li>We had a bug that caused the debugger not to run normally when using Matplotlib and it was solved</li>
-						</ul>
-					</li>
 					<li>An error displayed when trying to run Jupyter Notebook’ cells using managed and configured Jupyter servers that was not allowing Jupyter cells to run is now resolved</li>
 					<li>We improved Jupyter’s server response error messages to be more user friendly</li>
 					<li>A bug we had for imported names that was causing them to be imported again after inlining a function was fixed</li>
 					<li>AltGr keymaps for certain characters that were not working are now fixed</li>
 					<li>New SQL completion suggestions of join conditions based on column or table name match and auto-inject SQL by literals</li>
 					<li>Some JavaScript and Vue.js inspection issues were resolved</li>
+				</ul>
+				The PyCharm debugger got some fixes:
+				<ul>
+					<li>The issue causing the debugger to hang when a syntax error was encountered was resolved</li>
+					<li>When classes were given certain names, the debugger would be unable to inspect their variables, this is no longer a problem</li>
+					<li>Exceptions thrown when debugging a project with multiprocessing modules will not stop the debugger anymore</li>
+					<li>An issue that caused debugger functions like “Step into” to not work properly in our latest release was solved</li>
+					<li>We had a bug that caused the debugger not to run normally when using Matplotlib and it was solved</li>
 				</ul>
 			</description>
 		</release>

--- a/com.jetbrains.PyCharm-Community.yaml
+++ b/com.jetbrains.PyCharm-Community.yaml
@@ -1,6 +1,6 @@
 app-id: com.jetbrains.PyCharm-Community
 runtime: org.freedesktop.Sdk
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: pycharm
 separate-locales: false

--- a/com.jetbrains.PyCharm-Community.yaml
+++ b/com.jetbrains.PyCharm-Community.yaml
@@ -68,8 +68,8 @@ modules:
       - cat idea.properties | tee -a ${FLATPAK_DEST}/bin/idea.properties
     sources:
       - type: file
-        url: https://download.jetbrains.com/python/pycharm-community-2023.3.3.tar.gz
-        sha256: f71513f428f5df3b97b09c415967ff2db3a4e7172f293e621b3f04cd1d695443
+        url: https://download.jetbrains.com/python/pycharm-community-2024.1.1.tar.gz
+        sha256: 715f30966c5597adc6ef544051a796de8a6cc5a5182938b8e14a1e6ad5e5edfd
         dest-filename: pycharm-community.tar.gz
         x-checker-data:
           type: jetbrains

--- a/python3-poetry.yaml
+++ b/python3-poetry.yaml
@@ -111,8 +111,8 @@ sources:
     url: https://files.pythonhosted.org/packages/64/de/375aa14daaee107f987da76ca32f7a907fea00fa8b8afb67dc09bec0de91/pyrsistent-0.19.3-py3-none-any.whl
     sha256: ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64
   - type: file
-    url: https://files.pythonhosted.org/packages/c0/35/810a00f4f722f62b763bfdad3f592075bfa2348ed49ced381d20e75ae4e7/rapidfuzz-2.13.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-    sha256: 53dcae85956853b787c27c1cb06f18bb450e22cf57a4ad3444cf03b8ff31724a
+    url: https://files.pythonhosted.org/packages/94/c2/7707fd4cecfb026d3cbc7fadebfd9203828c0c2bfedd5c476ca633f7b8cb/rapidfuzz-2.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+    sha256: c35da09ab9797b020d0d4f07a66871dfc70ea6566363811090353ea971748b5a
   - type: file
     url: https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl
     sha256: 64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa


### PR DESCRIPTION
- fixed appstream by changing formatting in an old changelog
- updated runtime like in PyCharm-Professional: https://github.com/flathub/com.jetbrains.PyCharm-Professional/commit/0025f1dd45f7e6178b4e6f206724a5405bd844b3